### PR TITLE
fix: remove unnecessary `mounted` gate from Radix components

### DIFF
--- a/src/components/ContactMenu.tsx
+++ b/src/components/ContactMenu.tsx
@@ -1,5 +1,5 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { socialBarData } from '@/data/social-bar'
 
@@ -12,18 +12,7 @@ const ANIMATION_CLASSES = [
 ]
 
 export default function ContactMenu() {
-  const [mounted, setMounted] = useState(false)
   const [isOpen, setIsOpen] = useState(false)
-
-  useEffect(() => setMounted(true), [])
-
-  if (!mounted) {
-    return (
-      <div className="w-fit">
-        <span className="w-fit font-bold text-2xl text-theme-700">CONTACT</span>
-      </div>
-    )
-  }
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen} className="w-fit">

--- a/src/components/ui/sticky-back-button.tsx
+++ b/src/components/ui/sticky-back-button.tsx
@@ -1,4 +1,3 @@
-import { Link } from '@tanstack/react-router'
 import { ChevronLeft } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
@@ -6,12 +5,7 @@ import { SheetClose } from '@/components/ui/sheet'
 
 export function StickyBackButton() {
   const [isSticky, setIsSticky] = useState(false)
-  const [mounted, setMounted] = useState(false)
   const sentinelRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    setMounted(true)
-  }, [])
 
   useEffect(() => {
     const sentinel = sentinelRef.current
@@ -35,33 +29,15 @@ export function StickyBackButton() {
 
   return (
     <>
-      {/* Sentinel element for detecting sticky state */}
       <div ref={sentinelRef} className="pointer-events-none absolute top-0 h-px" />
 
-      {/* Sticky Back Button */}
       <div className="sticky top-0 z-10 mb-4 flex w-full justify-end">
-        {mounted ? (
-          <Button asChild variant="ghost" size="lg" className={buttonClassName}>
-            <SheetClose data-umami-event="Back to Home Clicked">
-              <ChevronLeft className="h-4 w-4" />
-              <span className="font-semibold">Back to Home</span>
-            </SheetClose>
-          </Button>
-        ) : (
-          // SSR fallback: plain link without Radix SheetClose
-          <Button asChild variant="ghost" size="lg" className={buttonClassName}>
-            <Link
-              to="/"
-              preload="intent"
-              startTransition
-              viewTransition
-              data-umami-event="Back to Home Clicked"
-            >
-              <ChevronLeft className="h-4 w-4" />
-              <span className="font-semibold">Back to Home</span>
-            </Link>
-          </Button>
-        )}
+        <Button asChild variant="ghost" size="lg" className={buttonClassName}>
+          <SheetClose data-umami-event="Back to Home Clicked">
+            <ChevronLeft className="h-4 w-4" />
+            <span className="font-semibold">Back to Home</span>
+          </SheetClose>
+        </Button>
       </div>
     </>
   )

--- a/src/routes/_home/route.tsx
+++ b/src/routes/_home/route.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Outlet, useLocation, useNavigate } from '@tanstack/react-router'
-import { Suspense, useDeferredValue, useEffect, useState } from 'react'
+import { Suspense, useDeferredValue } from 'react'
 import { SheetPage } from '@/components/layout/SheetPage'
 import { Sheet } from '@/components/ui/sheet'
 import HomePage from '@/pages/home'
@@ -14,7 +14,6 @@ export const Route = createFileRoute('/_home')({
 })
 
 function RouteComponent() {
-  const [mounted, setMounted] = useState(false)
   const { pathname } = useLocation()
   const deferredPathname = useDeferredValue(pathname)
 
@@ -22,8 +21,6 @@ function RouteComponent() {
   const sheetTitle = SHEET_TITLES[deferredPathname] ?? 'Page'
 
   const navigate = useNavigate()
-
-  useEffect(() => setMounted(true), [])
 
   const onSheetOpenChange = (open: boolean) => {
     if (!open) {
@@ -34,21 +31,15 @@ function RouteComponent() {
   return (
     <>
       <HomePage />
-      {sheetIsOpen &&
-        (mounted ? (
-          <Sheet open={true} onOpenChange={onSheetOpenChange}>
-            <SheetPage title={sheetTitle}>
-              <Suspense fallback={null}>
-                <Outlet />
-              </Suspense>
-            </SheetPage>
-          </Sheet>
-        ) : (
-          <div className="fixed inset-y-0 right-0 z-50 w-full overflow-y-auto bg-background p-6 shadow-lg lg:w-[66vw]">
-            <h1 className="sr-only">{sheetTitle}</h1>
-            <Outlet />
-          </div>
-        ))}
+      {sheetIsOpen && (
+        <Sheet open={true} onOpenChange={onSheetOpenChange}>
+          <SheetPage title={sheetTitle}>
+            <Suspense fallback={null}>
+              <Outlet />
+            </Suspense>
+          </SheetPage>
+        </Sheet>
+      )}
     </>
   )
 }


### PR DESCRIPTION
## Summary

Resolves #555.

Removes the `useState(mounted)` + `useEffect` gate from three components that rendered fallback markup on SSR and swapped to the real Radix component post-mount:

- `src/routes/_home/route.tsx` — `<Sheet>` gate
- `src/components/ContactMenu.tsx` — `<Collapsible>` gate
- `src/components/ui/sticky-back-button.tsx` — `<SheetClose>` gate

The gate was introduced in #537 as a workaround for a Radix hydration warning, but with React 19.2 and current Radix versions (`@radix-ui/react-dialog@1.1.15`, `@radix-ui/react-collapsible@1.1.12`) `useId()` is stable across SSR/client, so the workaround no longer serves a purpose.

## Why this is safe

Deployed to an ad-hoc SST stage (`radix-test.martinmiglio.dev`) and verified:

- Hydration error counts on `/`, `/about`, `/cv` are unchanged vs. production. The React #418 error that still appears on `/about` and `/cv` originates in the root route's `HeadContent` asset ordering (server omits `<title>` entirely; see follow-up issue), not in the Radix components that this PR touches.
- Removing the gate removes one double-render per visit and restores real DOM structure to SSR output (better for bots/no-JS).

## Test plan

- [x] Verified on deployed stage: `/`, `/about`, `/cv` all render correctly, sheet open/close works, contact menu expands, sticky back button remains functional.
- [x] `bun run check` + `tsc --noEmit` pass.
- [ ] Reviewer: verify sheet-open feels no worse than master (this PR is not expected to *improve* perf; it's a cleanup. Perf win comes in a follow-up PR.)