### PR TITLE
fix: put title in head.meta so SSR emits <title>

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -8,8 +8,10 @@ import NotFoundPage from '@/pages/404'
 
 export const Route = createRootRoute({
   head: () => ({
-    title: 'Martin Miglio',
     meta: [
+      {
+        title: 'Martin Miglio'
+      },
       {
         charSet: 'utf-8'
       },


### PR DESCRIPTION
## Summary
- Move `title` from the top-level `head()` return into the `meta` array in `src/routes/__root.tsx`. TanStack Start 1.136's SSR head emitter silently drops top-level `title`, which is why `curl https://martinmiglio.dev/` returned zero `<title>` tags and React #418 fired on every navigation.
- The canonical shape per current TanStack docs is `meta: [{ title: '...' }, ...]`.

Fixes #558. Likely also relieves the hydration-driven tree regeneration that was suspected of stalling the sheet-open frame in #555.

## Test plan
- [ ] `curl http://localhost:3000/ | grep '<title'` returns `<title>Martin Miglio</title>`
- [ ] `/`, `/about`, `/cv` render without React #418 in the browser console
- [ ] After deploy: `curl -s https://martinmiglio.dev/{,about,cv} | grep '<title'` all match
- [ ] Re-test the sheet-open transition from #555 to see if the frame drops ease