### PR TITLE
ci: own production + develop deploys in GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,57 @@
+name: Deploy
+
+on:
+  push:
+    branches: [master, develop]
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: deploy-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - uses: actions/cache@v4
+        with:
+          path: .sst/platform
+          key: sst-${{ runner.os }}-${{ hashFiles('bun.lock', 'sst.config.ts') }}
+          restore-keys: |
+            sst-${{ runner.os }}-
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - run: bun install --frozen-lockfile
+
+      - name: Resolve stage
+        id: stage
+        run: |
+          if [ "${{ github.ref_name }}" = "master" ]; then
+            echo "name=production" >> $GITHUB_OUTPUT
+          else
+            echo "name=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Deploy
+        run: bun sst deploy --stage ${{ steps.stage.outputs.name }}

--- a/README.md
+++ b/README.md
@@ -2,24 +2,30 @@
 
 ## Deployments
 
-Three stages, two mechanisms:
+All deploys run in GitHub Actions via OIDC. No SST Console autodeploy.
 
-| Stage        | Trigger           | Domain                     | Owner                                                   |
-| ------------ | ----------------- | -------------------------- | ------------------------------------------------------- |
-| `production` | push to `master`  | `martinmiglio.dev`         | SST Console autodeploy                                  |
-| `develop`    | push to `develop` | `develop.martinmiglio.dev` | SST Console autodeploy                                  |
-| `pr-<N>`     | open/sync PR      | `pr-<N>.martinmiglio.dev`  | GitHub Actions (`.github/workflows/deploy-preview.yml`) |
+| Stage        | Trigger           | Domain                     | Workflow                               |
+| ------------ | ----------------- | -------------------------- | -------------------------------------- |
+| `production` | push to `master`  | `martinmiglio.dev`         | `.github/workflows/deploy.yml`         |
+| `develop`    | push to `develop` | `develop.martinmiglio.dev` | `.github/workflows/deploy.yml`         |
+| `pr-<N>`     | open/sync PR      | `pr-<N>.martinmiglio.dev`  | `.github/workflows/deploy-preview.yml` |
 
 PR previews are torn down automatically when the PR closes (`destroy-preview.yml` runs `sst remove --stage pr-<N>`).
 
 ### One-time bootstrap (per AWS account)
 
-The PR preview workflow uses GitHub OIDC to assume a deploy role in AWS. Provision it with:
+The deploy workflows use GitHub OIDC to assume a role in AWS. Provision it with:
 
 ```bash
 bun sst deploy --config infra/oidc.config.ts --stage production
 ```
 
-This creates (or reuses) the GitHub OIDC provider and a `github-actions-sst-deploy` role scoped to `repo:martinmiglio/site:*` with `AdministratorAccess`. Copy the printed `deployRoleArn` into the repo secret `AWS_ROLE_ARN` (Settings → Secrets and variables → Actions).
+This creates (or reuses) the GitHub OIDC provider and a `github-actions-sst-deploy-site` role. The trust policy accepts tokens from three `sub` values only:
 
-The config is idempotent — re-running adopts the existing OIDC provider.
+- `repo:martinmiglio/site:pull_request`
+- `repo:martinmiglio/site:ref:refs/heads/master`
+- `repo:martinmiglio/site:ref:refs/heads/develop`
+
+Copy the printed `deployRoleArn` into the repo secret `AWS_ROLE_ARN` (Settings → Secrets and variables → Actions).
+
+The config is idempotent — re-running adopts the existing OIDC provider and updates the trust policy.

--- a/infra/oidc.config.ts
+++ b/infra/oidc.config.ts
@@ -44,7 +44,11 @@ export default $config({
             Condition: {
               StringEquals: {
                 'token.actions.githubusercontent.com:aud': 'sts.amazonaws.com',
-                'token.actions.githubusercontent.com:sub': 'repo:martinmiglio/site:pull_request'
+                'token.actions.githubusercontent.com:sub': [
+                  'repo:martinmiglio/site:pull_request',
+                  'repo:martinmiglio/site:ref:refs/heads/master',
+                  'repo:martinmiglio/site:ref:refs/heads/develop'
+                ]
               }
             }
           }

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -45,20 +45,5 @@ export default $config({
       url: `https://${baseDomain}`,
       appUrl: app.url
     }
-  },
-  console: {
-    autodeploy: {
-      target(event) {
-        if (event.type === 'branch' && event.action === 'pushed') {
-          if (event.branch === 'develop') {
-            return { stage: 'develop' }
-          }
-
-          if (event.branch === 'master') {
-            return { stage: 'production' }
-          }
-        }
-      }
-    }
   }
 })


### PR DESCRIPTION
## Summary
Moves `production` and `develop` deploys off SST Console autodeploy and into GitHub Actions, matching the PR-preview pattern introduced in #563. After this lands, GitHub Actions is the single source for all deploys.

- **`.github/workflows/deploy.yml`** — on push to `master` → `sst deploy --stage production`; on push to `develop` → `sst deploy --stage develop`.
- **`sst.config.ts`** — drops the `console.autodeploy` block entirely.
- **`infra/oidc.config.ts`** — widens trust from `pull_request` only to also accept `refs/heads/master` and `refs/heads/develop` (still `StringEquals` array, no wildcards).
- **`README.md`** — updated.

## Why
The Console envs were deleted and the plan is to consolidate on GitHub Actions so every deploy shows up as a PR/commit check with logs alongside the code.

## Test plan
- [ ] OIDC trust has already been applied locally (`bun sst deploy --config infra/oidc.config.ts --stage production`). No manual step needed on merge.
- [ ] Preview deploy for this PR succeeds (`pr-<N>.martinmiglio.dev` live via existing `deploy-preview.yml`).
- [ ] After merge to `master` → `Deploy` workflow deploys `production` stage, `martinmiglio.dev` reflects the change.
- [ ] Push to `develop` → `Deploy` workflow deploys `develop` stage.
- [ ] No SST Console autodeploy runs are triggered.