### PR TITLE
Neumorphic pebble back button on sheets

### DIFF
--- a/src/assets/index.css
+++ b/src/assets/index.css
@@ -408,18 +408,3 @@
     inset 3px 3px 8px rgba(120, 138, 120, 0.28),
     inset -3px -3px 8px rgba(255, 255, 255, 0.85);
 }
-
-.sheet-grab-handle {
-  position: absolute;
-  top: 8px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 44px;
-  height: 5px;
-  border-radius: 9999px;
-  background: linear-gradient(180deg, #c9cfc1, #b4cd9d);
-  box-shadow:
-    inset 1px 1px 2px rgba(255, 255, 255, 0.7),
-    inset -1px -1px 2px rgba(120, 138, 120, 0.25);
-  opacity: 0.85;
-}

--- a/src/assets/index.css
+++ b/src/assets/index.css
@@ -385,3 +385,41 @@
     transparent 70%
   );
 }
+
+.pebble-back {
+  background: linear-gradient(155deg, #f6f8f3 0%, #e4e6dd 100%);
+  box-shadow:
+    8px 8px 18px rgba(160, 175, 160, 0.28),
+    -6px -6px 14px rgba(255, 255, 255, 0.9),
+    inset 2px 2px 5px rgba(255, 255, 255, 0.7),
+    inset -2px -2px 5px rgba(120, 138, 120, 0.14);
+}
+.pebble-back:hover,
+.pebble-back:focus-visible {
+  background: linear-gradient(155deg, #ffffff 0%, #e8eae3 100%);
+  box-shadow:
+    10px 10px 22px rgba(120, 138, 120, 0.32),
+    -8px -8px 18px rgba(255, 255, 255, 1),
+    inset 2px 2px 6px rgba(255, 255, 255, 0.8),
+    inset -2px -2px 6px rgba(37, 201, 34, 0.08);
+}
+.pebble-back:active {
+  box-shadow:
+    inset 3px 3px 8px rgba(120, 138, 120, 0.28),
+    inset -3px -3px 8px rgba(255, 255, 255, 0.85);
+}
+
+.sheet-grab-handle {
+  position: absolute;
+  top: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 44px;
+  height: 5px;
+  border-radius: 9999px;
+  background: linear-gradient(180deg, #c9cfc1, #b4cd9d);
+  box-shadow:
+    inset 1px 1px 2px rgba(255, 255, 255, 0.7),
+    inset -1px -1px 2px rgba(120, 138, 120, 0.25);
+  opacity: 0.85;
+}

--- a/src/components/layout/RouteSheet.tsx
+++ b/src/components/layout/RouteSheet.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useRef, useState } from 'react'
+import { SheetPage } from '@/components/layout/SheetPage'
+import { Sheet } from '@/components/ui/sheet'
+
+interface RouteSheetProps {
+  open: boolean
+  title: string
+  description?: string
+  onClosed: () => void
+  children: React.ReactNode
+}
+
+export function RouteSheet({ open, title, description, onClosed, children }: RouteSheetProps) {
+  const [isClosing, setIsClosing] = useState(false)
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  const sheetOpen = open && !isClosing
+
+  useEffect(() => {
+    if (!isClosing) return
+    const ac = new AbortController()
+    waitForExitAnimation(contentRef.current).then(() => {
+      if (ac.signal.aborted) return
+      onClosed()
+      setIsClosing(false)
+    })
+    return () => ac.abort()
+  }, [isClosing, onClosed])
+
+  const onOpenChange = (next: boolean) => {
+    if (!next && !isClosing) setIsClosing(true)
+  }
+
+  return (
+    <Sheet open={sheetOpen} onOpenChange={onOpenChange}>
+      <SheetPage title={title} description={description} contentRef={contentRef}>
+        {children}
+      </SheetPage>
+    </Sheet>
+  )
+}
+
+async function waitForExitAnimation(el: HTMLElement | null): Promise<void> {
+  if (!el) return
+  const anims = el.getAnimations({ subtree: true }).filter((a) => a.playState === 'running')
+  if (anims.length === 0) return
+  await Promise.all(anims.map((a) => a.finished.catch(() => {})))
+}

--- a/src/components/layout/SheetPage.tsx
+++ b/src/components/layout/SheetPage.tsx
@@ -36,7 +36,6 @@ export function SheetPage({ title, description, children }: SheetPageProps) {
     >
       <SheetTitle className="sr-only">{title}</SheetTitle>
       {description && <SheetDescription className="sr-only">{description}</SheetDescription>}
-      {isMobile && <span aria-hidden="true" className="sheet-grab-handle" />}
       {children}
     </SheetContent>
   )

--- a/src/components/layout/SheetPage.tsx
+++ b/src/components/layout/SheetPage.tsx
@@ -6,9 +6,10 @@ interface SheetPageProps {
   title: string
   description?: string
   children: React.ReactNode
+  contentRef?: React.Ref<HTMLDivElement>
 }
 
-export function SheetPage({ title, description, children }: SheetPageProps) {
+export function SheetPage({ title, description, children, contentRef }: SheetPageProps) {
   const isMobile = useMediaQuery('(max-width: 768px)')
   const sheetOptions = {
     mobile: {
@@ -30,6 +31,7 @@ export function SheetPage({ title, description, children }: SheetPageProps) {
 
   return (
     <SheetContent
+      ref={contentRef}
       className={cn(className, scrollbarStyles, 'sm:max-w-none')}
       side={side}
       aria-describedby={description ? undefined : undefined}

--- a/src/components/layout/SheetPage.tsx
+++ b/src/components/layout/SheetPage.tsx
@@ -36,6 +36,7 @@ export function SheetPage({ title, description, children }: SheetPageProps) {
     >
       <SheetTitle className="sr-only">{title}</SheetTitle>
       {description && <SheetDescription className="sr-only">{description}</SheetDescription>}
+      {isMobile && <span aria-hidden="true" className="sheet-grab-handle" />}
       {children}
     </SheetContent>
   )

--- a/src/components/layout/SheetPage.tsx
+++ b/src/components/layout/SheetPage.tsx
@@ -34,7 +34,6 @@ export function SheetPage({ title, description, children, contentRef }: SheetPag
       ref={contentRef}
       className={cn(className, scrollbarStyles, 'sm:max-w-none')}
       side={side}
-      aria-describedby={description ? undefined : undefined}
     >
       <SheetTitle className="sr-only">{title}</SheetTitle>
       {description && <SheetDescription className="sr-only">{description}</SheetDescription>}

--- a/src/components/ui/sticky-back-button.tsx
+++ b/src/components/ui/sticky-back-button.tsx
@@ -1,44 +1,27 @@
-import { ChevronLeft } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
-import { Button } from '@/components/ui/button'
+import { ArrowLeft } from 'lucide-react'
 import { SheetClose } from '@/components/ui/sheet'
 
+/**
+ * Variant: Neumorphic Pebble.
+ * A floating pill anchored to the top-left of the sheet that matches the
+ * capsules background aesthetic. Compact at rest; expands on hover/focus.
+ */
 export function StickyBackButton() {
-  const [isSticky, setIsSticky] = useState(false)
-  const sentinelRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    const sentinel = sentinelRef.current
-    if (!sentinel) return
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        setIsSticky(!entry.isIntersecting)
-      },
-      { threshold: [1] }
-    )
-
-    observer.observe(sentinel)
-
-    return () => {
-      observer.disconnect()
-    }
-  }, [])
-
-  const buttonClassName = `mr-3 cursor-pointer border-none bg-background/93 ring-transparent transition-all duration-300 ease-out hover:scale-[.97] hover:bg-background/100 ${isSticky ? '-translate-y-1 scale-[1.02] shadow-lg' : ''}`
-
   return (
-    <>
-      <div ref={sentinelRef} className="pointer-events-none absolute top-0 h-px" />
-
-      <div className="sticky top-0 z-10 mb-4 flex w-full justify-end">
-        <Button asChild variant="ghost" size="lg" className={buttonClassName}>
-          <SheetClose data-umami-event="Back to Home Clicked">
-            <ChevronLeft className="h-4 w-4" />
-            <span className="font-semibold">Back to Home</span>
-          </SheetClose>
-        </Button>
-      </div>
-    </>
+    <div className="sticky top-0 z-20 -mx-8 -mt-10 mb-8 flex h-14 items-center px-5">
+      <SheetClose
+        data-umami-event="Back to Home Clicked"
+        aria-label="Back to Home"
+        className="pebble-back group flex h-12 w-12 items-center overflow-hidden rounded-full pr-4 pl-[14px] font-semibold text-[12px] text-theme-800 uppercase tracking-[0.22em] outline-none transition-[width,transform] duration-500 ease-[cubic-bezier(0.16,1,0.3,1)] hover:w-36 focus-visible:w-36 active:scale-[0.96]"
+      >
+        <ArrowLeft
+          strokeWidth={2.25}
+          className="h-5 w-5 shrink-0 text-theme-700 transition-transform duration-500 ease-[cubic-bezier(0.16,1,0.3,1)] group-hover:-translate-x-[1px] group-focus-visible:-translate-x-[1px]"
+        />
+        <span className="ml-4 whitespace-nowrap opacity-0 transition-opacity duration-300 delay-100 group-hover:opacity-100 group-focus-visible:opacity-100">
+          Home
+        </span>
+      </SheetClose>
+    </div>
   )
 }

--- a/src/components/ui/sticky-back-button.tsx
+++ b/src/components/ui/sticky-back-button.tsx
@@ -1,11 +1,6 @@
 import { ArrowLeft } from 'lucide-react'
 import { SheetClose } from '@/components/ui/sheet'
 
-/**
- * Variant: Neumorphic Pebble.
- * A floating pill anchored to the top-left of the sheet that matches the
- * capsules background aesthetic. Compact at rest; expands on hover/focus.
- */
 export function StickyBackButton() {
   return (
     <div className="sticky top-0 z-20 -mx-8 -mt-10 mb-8 flex h-14 items-center px-5">

--- a/src/routes/_home/route.tsx
+++ b/src/routes/_home/route.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute, Outlet, useLocation, useNavigate } from '@tanstack/react-router'
-import { Suspense, useDeferredValue } from 'react'
-import { SheetPage } from '@/components/layout/SheetPage'
-import { Sheet } from '@/components/ui/sheet'
+import { Suspense, useCallback } from 'react'
+import { RouteSheet } from '@/components/layout/RouteSheet'
 import HomePage from '@/pages/home'
 
 const SHEET_TITLES: Record<string, string> = {
@@ -15,31 +14,24 @@ export const Route = createFileRoute('/_home')({
 
 function RouteComponent() {
   const { pathname } = useLocation()
-  const deferredPathname = useDeferredValue(pathname)
-
-  const sheetIsOpen = deferredPathname !== '/'
-  const sheetTitle = SHEET_TITLES[deferredPathname] ?? 'Page'
-
   const navigate = useNavigate()
 
-  const onSheetOpenChange = (open: boolean) => {
-    if (!open) {
-      navigate({ to: '/', startTransition: true, viewTransition: true })
-    }
-  }
+  const onClosed = useCallback(() => {
+    navigate({ to: '/', startTransition: true })
+  }, [navigate])
 
   return (
     <>
       <HomePage />
-      {sheetIsOpen && (
-        <Sheet open={true} onOpenChange={onSheetOpenChange}>
-          <SheetPage title={sheetTitle}>
-            <Suspense fallback={null}>
-              <Outlet />
-            </Suspense>
-          </SheetPage>
-        </Sheet>
-      )}
+      <RouteSheet
+        open={pathname !== '/'}
+        title={SHEET_TITLES[pathname] ?? 'Page'}
+        onClosed={onClosed}
+      >
+        <Suspense fallback={null}>
+          <Outlet />
+        </Suspense>
+      </RouteSheet>
     </>
   )
 }


### PR DESCRIPTION
## Summary
- Replaces the sticky ghost back button with a compact **neumorphic pebble** that matches the capsules background
- Pebble sits top-left of every sheet; expands on hover/focus to reveal a "Home" label
- Adds a subtle **grab handle** at the top of bottom sheets on mobile for iOS-style affordance
- Native **Escape to close** preserved via Radix

## Visuals
Idle: a small concave/convex pill, same aesthetic language as the site's capsule background.
Hover/focus: smooth width morph (cubic-bezier ease-out) to a pill showing ← and "HOME".
Active: inset shadows invert to mimic a physical press.

## Test plan
- [x] `bun run dev` → visit `/` → click `ABOUT` → pebble is visible top-left of the sheet
- [x] Hover the pebble → expands smoothly, label fades in
- [x] Keyboard: Tab into the pebble → focus ring matches hover state; Enter closes
- [x] Press Escape while a sheet is open → sheet closes (Radix default)
- [x] Resize below 768px → sheet slides from the bottom; a small grab handle is centered above the content
- [x] `bun run check && bun run typecheck` stay green