### PR TITLE
chore: gitignore .claude and legacy .husky

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# Local agent scratch + legacy husky hooks dir (hooks now managed by lefthook)
+/.claude/
+/.husky/
+
 /.next
 
 # Default ignored files


### PR DESCRIPTION
## Summary
- Adds `/.claude/` (local agent scratch) and `/.husky/` (legacy pre-commit hook dir — hooks are now managed by lefthook) to `.gitignore`
- Keeps these directories out of `git status` output on fresh checkouts

## Test plan
- [ ] After checkout, `git status` no longer lists `.claude/` or `.husky/` as untracked
- [ ] `bun install` + `bun run check` stay green