### PR TITLE
feat(ui): preserve sheet close animation by deferring navigate

### DIFF
--- a/src/components/layout/RouteSheet.tsx
+++ b/src/components/layout/RouteSheet.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useRef, useState } from 'react'
+import { SheetPage } from '@/components/layout/SheetPage'
+import { Sheet } from '@/components/ui/sheet'
+
+interface RouteSheetProps {
+  open: boolean
+  title: string
+  description?: string
+  onClosed: () => void
+  children: React.ReactNode
+}
+
+export function RouteSheet({ open, title, description, onClosed, children }: RouteSheetProps) {
+  const [isClosing, setIsClosing] = useState(false)
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  const sheetOpen = open && !isClosing
+
+  useEffect(() => {
+    if (!isClosing) return
+    const ac = new AbortController()
+    waitForExitAnimation(contentRef.current, ac.signal).then(() => {
+      if (ac.signal.aborted) return
+      onClosed()
+      setIsClosing(false)
+    })
+    return () => ac.abort()
+  }, [isClosing, onClosed])
+
+  const onOpenChange = (next: boolean) => {
+    if (!next && !isClosing) setIsClosing(true)
+  }
+
+  return (
+    <Sheet open={sheetOpen} onOpenChange={onOpenChange}>
+      <SheetPage title={title} description={description} contentRef={contentRef}>
+        {children}
+      </SheetPage>
+    </Sheet>
+  )
+}
+
+/**
+ * Awaits two frames so React commits open=false and Radix flips
+ * data-state="closed" before sampling the running animations.
+ */
+async function waitForExitAnimation(el: HTMLElement | null, signal: AbortSignal): Promise<void> {
+  if (!el) return
+  await nextFrame()
+  if (signal.aborted) return
+  await nextFrame()
+  if (signal.aborted) return
+  const anims = el.getAnimations({ subtree: true }).filter((a) => a.playState === 'running')
+  if (anims.length === 0) return
+  await Promise.all(anims.map((a) => a.finished.catch(() => {})))
+}
+
+function nextFrame(): Promise<void> {
+  return new Promise((resolve) => requestAnimationFrame(() => resolve()))
+}

--- a/src/components/layout/RouteSheet.tsx
+++ b/src/components/layout/RouteSheet.tsx
@@ -19,7 +19,7 @@ export function RouteSheet({ open, title, description, onClosed, children }: Rou
   useEffect(() => {
     if (!isClosing) return
     const ac = new AbortController()
-    waitForExitAnimation(contentRef.current, ac.signal).then(() => {
+    waitForExitAnimation(contentRef.current).then(() => {
       if (ac.signal.aborted) return
       onClosed()
       setIsClosing(false)
@@ -40,21 +40,9 @@ export function RouteSheet({ open, title, description, onClosed, children }: Rou
   )
 }
 
-/**
- * Awaits two frames so React commits open=false and Radix flips
- * data-state="closed" before sampling the running animations.
- */
-async function waitForExitAnimation(el: HTMLElement | null, signal: AbortSignal): Promise<void> {
+async function waitForExitAnimation(el: HTMLElement | null): Promise<void> {
   if (!el) return
-  await nextFrame()
-  if (signal.aborted) return
-  await nextFrame()
-  if (signal.aborted) return
   const anims = el.getAnimations({ subtree: true }).filter((a) => a.playState === 'running')
   if (anims.length === 0) return
   await Promise.all(anims.map((a) => a.finished.catch(() => {})))
-}
-
-function nextFrame(): Promise<void> {
-  return new Promise((resolve) => requestAnimationFrame(() => resolve()))
 }

--- a/src/components/layout/SheetPage.tsx
+++ b/src/components/layout/SheetPage.tsx
@@ -6,9 +6,10 @@ interface SheetPageProps {
   title: string
   description?: string
   children: React.ReactNode
+  contentRef?: React.Ref<HTMLDivElement>
 }
 
-export function SheetPage({ title, description, children }: SheetPageProps) {
+export function SheetPage({ title, description, children, contentRef }: SheetPageProps) {
   const isMobile = useMediaQuery('(max-width: 768px)')
   const sheetOptions = {
     mobile: {
@@ -30,6 +31,7 @@ export function SheetPage({ title, description, children }: SheetPageProps) {
 
   return (
     <SheetContent
+      ref={contentRef}
       className={cn(className, scrollbarStyles, 'sm:max-w-none')}
       side={side}
       aria-describedby={description ? undefined : undefined}

--- a/src/routes/_home/route.tsx
+++ b/src/routes/_home/route.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Outlet, useLocation, useNavigate } from '@tanstack/react-router'
-import { Suspense, useDeferredValue } from 'react'
+import { Suspense, useRef, useState } from 'react'
 import { SheetPage } from '@/components/layout/SheetPage'
 import { Sheet } from '@/components/ui/sheet'
 import HomePage from '@/pages/home'
@@ -9,37 +9,46 @@ const SHEET_TITLES: Record<string, string> = {
   '/cv': 'Experience'
 }
 
+const CLOSE_ANIMATION_MS = 300
+
 export const Route = createFileRoute('/_home')({
   component: RouteComponent
 })
 
 function RouteComponent() {
   const { pathname } = useLocation()
-  const deferredPathname = useDeferredValue(pathname)
-
-  const sheetIsOpen = deferredPathname !== '/'
-  const sheetTitle = SHEET_TITLES[deferredPathname] ?? 'Page'
-
   const navigate = useNavigate()
 
-  const onSheetOpenChange = (open: boolean) => {
-    if (!open) {
-      navigate({ to: '/', startTransition: true, viewTransition: true })
+  const [isClosing, setIsClosing] = useState(false)
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const open = pathname !== '/' && !isClosing
+  // While closing, pathname is still /about or /cv, so Outlet keeps rendering
+  // the current page content during the exit animation.
+  const sheetTitle = SHEET_TITLES[pathname] ?? 'Page'
+
+  const onSheetOpenChange = (next: boolean) => {
+    if (!next && !isClosing) {
+      setIsClosing(true)
+      if (closeTimer.current) clearTimeout(closeTimer.current)
+      closeTimer.current = setTimeout(() => {
+        navigate({ to: '/', startTransition: true })
+        setIsClosing(false)
+        closeTimer.current = null
+      }, CLOSE_ANIMATION_MS)
     }
   }
 
   return (
     <>
       <HomePage />
-      {sheetIsOpen && (
-        <Sheet open={true} onOpenChange={onSheetOpenChange}>
-          <SheetPage title={sheetTitle}>
-            <Suspense fallback={null}>
-              <Outlet />
-            </Suspense>
-          </SheetPage>
-        </Sheet>
-      )}
+      <Sheet open={open} onOpenChange={onSheetOpenChange}>
+        <SheetPage title={sheetTitle}>
+          <Suspense fallback={null}>
+            <Outlet />
+          </Suspense>
+        </SheetPage>
+      </Sheet>
     </>
   )
 }

--- a/src/routes/_home/route.tsx
+++ b/src/routes/_home/route.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute, Outlet, useLocation, useNavigate } from '@tanstack/react-router'
-import { Suspense, useEffect, useState } from 'react'
-import { SheetPage } from '@/components/layout/SheetPage'
-import { Sheet } from '@/components/ui/sheet'
+import { Suspense, useCallback } from 'react'
+import { RouteSheet } from '@/components/layout/RouteSheet'
 import HomePage from '@/pages/home'
 
 const SHEET_TITLES: Record<string, string> = {
@@ -17,60 +16,22 @@ function RouteComponent() {
   const { pathname } = useLocation()
   const navigate = useNavigate()
 
-  const [isClosing, setIsClosing] = useState(false)
-
-  const open = pathname !== '/' && !isClosing
-  // While closing, pathname is still /about or /cv, so Outlet keeps rendering
-  // the current page content during the exit animation.
-  const sheetTitle = SHEET_TITLES[pathname] ?? 'Page'
-
-  useEffect(() => {
-    if (!isClosing) return
-    let cancelled = false
-
-    const finish = () => {
-      if (cancelled) return
-      navigate({ to: '/', startTransition: true })
-      setIsClosing(false)
-    }
-
-    // Double rAF lets React commit the open={false} pass and Radix apply
-    // data-state="closed" (which triggers the Tailwind slide-out) before we
-    // read the running animations.
-    const raf = requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        if (cancelled) return
-        const dialog = document.querySelector('[role="dialog"]')
-        const anims =
-          dialog?.getAnimations({ subtree: true }).filter((a) => a.playState === 'running') ?? []
-        if (anims.length === 0) {
-          finish()
-          return
-        }
-        Promise.all(anims.map((a) => a.finished.catch(() => {}))).then(finish)
-      })
-    })
-
-    return () => {
-      cancelled = true
-      cancelAnimationFrame(raf)
-    }
-  }, [isClosing, navigate])
-
-  const onSheetOpenChange = (next: boolean) => {
-    if (!next && !isClosing) setIsClosing(true)
-  }
+  const onClosed = useCallback(() => {
+    navigate({ to: '/', startTransition: true })
+  }, [navigate])
 
   return (
     <>
       <HomePage />
-      <Sheet open={open} onOpenChange={onSheetOpenChange}>
-        <SheetPage title={sheetTitle}>
-          <Suspense fallback={null}>
-            <Outlet />
-          </Suspense>
-        </SheetPage>
-      </Sheet>
+      <RouteSheet
+        open={pathname !== '/'}
+        title={SHEET_TITLES[pathname] ?? 'Page'}
+        onClosed={onClosed}
+      >
+        <Suspense fallback={null}>
+          <Outlet />
+        </Suspense>
+      </RouteSheet>
     </>
   )
 }

--- a/src/routes/_home/route.tsx
+++ b/src/routes/_home/route.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Outlet, useLocation, useNavigate } from '@tanstack/react-router'
-import { Suspense, useRef, useState } from 'react'
+import { Suspense, useEffect, useState } from 'react'
 import { SheetPage } from '@/components/layout/SheetPage'
 import { Sheet } from '@/components/ui/sheet'
 import HomePage from '@/pages/home'
@@ -8,8 +8,6 @@ const SHEET_TITLES: Record<string, string> = {
   '/about': 'About',
   '/cv': 'Experience'
 }
-
-const CLOSE_ANIMATION_MS = 300
 
 export const Route = createFileRoute('/_home')({
   component: RouteComponent
@@ -20,23 +18,47 @@ function RouteComponent() {
   const navigate = useNavigate()
 
   const [isClosing, setIsClosing] = useState(false)
-  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const open = pathname !== '/' && !isClosing
   // While closing, pathname is still /about or /cv, so Outlet keeps rendering
   // the current page content during the exit animation.
   const sheetTitle = SHEET_TITLES[pathname] ?? 'Page'
 
-  const onSheetOpenChange = (next: boolean) => {
-    if (!next && !isClosing) {
-      setIsClosing(true)
-      if (closeTimer.current) clearTimeout(closeTimer.current)
-      closeTimer.current = setTimeout(() => {
-        navigate({ to: '/', startTransition: true })
-        setIsClosing(false)
-        closeTimer.current = null
-      }, CLOSE_ANIMATION_MS)
+  useEffect(() => {
+    if (!isClosing) return
+    let cancelled = false
+
+    const finish = () => {
+      if (cancelled) return
+      navigate({ to: '/', startTransition: true })
+      setIsClosing(false)
     }
+
+    // Double rAF lets React commit the open={false} pass and Radix apply
+    // data-state="closed" (which triggers the Tailwind slide-out) before we
+    // read the running animations.
+    const raf = requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (cancelled) return
+        const dialog = document.querySelector('[role="dialog"]')
+        const anims =
+          dialog?.getAnimations({ subtree: true }).filter((a) => a.playState === 'running') ?? []
+        if (anims.length === 0) {
+          finish()
+          return
+        }
+        Promise.all(anims.map((a) => a.finished.catch(() => {}))).then(finish)
+      })
+    })
+
+    return () => {
+      cancelled = true
+      cancelAnimationFrame(raf)
+    }
+  }, [isClosing, navigate])
+
+  const onSheetOpenChange = (next: boolean) => {
+    if (!next && !isClosing) setIsClosing(true)
   }
 
   return (


### PR DESCRIPTION
## Summary

Stacks on top of #578. The pebble back button currently navigates to `/` immediately, which unmounts the sheet before Radix can play its exit animation — the sheet appears to snap away.

This PR keeps the **URL as the single source of truth** for sheet visibility, but always mounts the Sheet wrapper and controls it via the `open` prop, with a small `isClosing` guard to defer `navigate('/')` until Radix's exit animation finishes.

## Changes

- New `src/components/layout/RouteSheet.tsx` — wrapper component that owns the `<Sheet>` JSX, the `isClosing` state, a `useRef<HTMLDivElement>` on the content node, and the close-animation effect. Router-agnostic; exposes an `onClosed` callback.
- New colocated helper `waitForExitAnimation(el)` — reads `el.getAnimations({ subtree: true }).filter(running)` and awaits `Promise.all(a.finished)`. Per CSS Animations Level 2 §6.2, `getAnimations()` is required to flush pending style itself, so no `requestAnimationFrame` dance is needed.
- `src/components/layout/SheetPage.tsx` — accepts a `contentRef` prop forwarded onto `SheetContent`, so the wrapper holds a real ref instead of querying `[role="dialog"]`.
- `src/routes/_home/route.tsx` — slimmed to declarative `<RouteSheet open={pathname !== '/'} title={...} onClosed={navigateHome}>`. No more inline `useState`/`useEffect`/rAF/querySelector at the route level.

## Why not local state at the route

An earlier prototype used `useState` mirroring the sheet's open state, synced to pathname via `useEffect`. That introduces two sources of truth (URL and local state) that must be reconciled. This implementation keeps pathname authoritative; `isClosing` is a transient animation guard scoped inside `RouteSheet`.

## Alternative

See the sibling PR for option C (View Transitions API, CSS-only). Sibling PRs, not stacked — mutually exclusive implementations.

## Test plan

- [x] Open `/`, click About — sheet slides in
- [x] Click back pebble — sheet slides out smoothly (no snap); current page content stays visible during exit
- [ ] Open `/cv` directly in URL — sheet is already open on load
- [x] Browser back/forward preserves behavior
- [x] Rapid back-clicks don't queue multiple navigations or leave stale timers