### PR TITLE
Render sheet inline so overlay routes ship in SSR HTML

### DIFF
--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -54,12 +54,12 @@ const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
 >(({ side = 'right', className, children, ...props }, ref) => (
-  <SheetPortal>
+  <>
     <SheetOverlay />
     <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
       {children}
     </SheetPrimitive.Content>
-  </SheetPortal>
+  </>
 ))
 SheetContent.displayName = SheetPrimitive.Content.displayName
 


### PR DESCRIPTION
## Summary
- Drop Radix Dialog's `Portal` wrapper from `SheetContent` so the route content lives in the document tree at SSR time.
- Fixes #582 — overlay routes (`/about`, `/cv`) now return real HTML to crawlers, LLM agents, and unfurlers instead of byte-identical home markup.

## Why this works
Radix Portal gates on a `useLayoutEffect`-driven `mounted` flag; that effect doesn't run during SSR, so the portal returned `null` and every descendant (including the nested `<Outlet/>`) emitted nothing. The sheet renders near the top of the tree with no `overflow:hidden` ancestor and no z-index battle, so the portal wasn't paying for itself. `SheetContent` is `position: fixed`, so its layout doesn't depend on where in the DOM tree it lives. Focus trap, escape-to-close, scroll lock, `aria-modal`, and the `inert`-on-siblings behavior all live on `Dialog.Content` and are unaffected.

No `location.state` flag, no manifest, no per-route contract. Future overlay routes inherit SSR for free.

## Test plan
- [ ] Preview deploy: `curl <preview>/about` and `curl <preview>/cv` — body contains the page heading, not just the home layout
- [ ] In-app navigation from `/`: click ABOUT/EXPERIENCE — sheet opens with existing animation
- [ ] Direct URL load of `/about` and `/cv` — sheet opens, content renders, no flicker
- [ ] Close sheet (overlay click, ESC, neumorphic back button) — exit animation plays, navigates to `/`
- [ ] Focus trap inside sheet still works (Tab cycles within sheet)
- [ ] Sheet still layers above `CapsulesBackground` and home content (z-50 holds)
- [ ] Mobile viewport: bottom-sheet variant still positions correctly