### PR TITLE
Serve Markdown variant via Accept header content negotiation

### DIFF
--- a/src/lib/markdown/accept.ts
+++ b/src/lib/markdown/accept.ts
@@ -1,0 +1,65 @@
+/**
+ * Parse an Accept header and return whether `text/markdown` is preferred over
+ * `text/html`. Implements enough of RFC 9110 §12.5.1 for the common cases:
+ * comma-separated entries, optional `;q=` weight, defaulting to q=1.0.
+ *
+ * Wildcards (`* /*`, `text/*`) match `text/html` for tie-breaking — agents that
+ * pass `* /*` get HTML by default.
+ */
+
+interface AcceptEntry {
+  type: string
+  q: number
+}
+
+const parseAccept = (header: string): AcceptEntry[] => {
+  return header
+    .split(',')
+    .map((part) => {
+      const trimmed = part.trim()
+      if (!trimmed) return null
+      const [rawType, ...params] = trimmed.split(';').map((s) => s.trim())
+      let q = 1
+      for (const p of params) {
+        const eq = p.indexOf('=')
+        if (eq < 0) continue
+        const key = p.slice(0, eq).trim()
+        const value = p.slice(eq + 1).trim()
+        if (key === 'q') {
+          const parsed = Number(value)
+          if (!Number.isNaN(parsed)) q = parsed
+        }
+      }
+      return rawType ? { type: rawType.toLowerCase(), q } : null
+    })
+    .filter((e): e is AcceptEntry => e !== null)
+}
+
+const matchQ = (entries: AcceptEntry[], target: string): number => {
+  let best = -1
+  for (const e of entries) {
+    if (e.type === target || e.type === '*/*') {
+      if (e.q > best) best = e.q
+      continue
+    }
+    const slash = target.indexOf('/')
+    if (slash > 0) {
+      const family = `${target.slice(0, slash)}/*`
+      if (e.type === family && e.q > best) best = e.q
+    }
+  }
+  return best
+}
+
+export const acceptPrefersMarkdown = (header: string | null): boolean => {
+  if (!header) return false
+  const entries = parseAccept(header)
+  if (!entries.length) return false
+  const md = matchQ(entries, 'text/markdown')
+  if (md <= 0) return false
+  const html = matchQ(entries, 'text/html')
+  // Strict preference: markdown must beat html. Equal q (e.g. `*/*` matches
+  // both at 1.0) means we keep serving HTML — browsers send `*/*` and would
+  // otherwise be misrouted.
+  return md > html
+}

--- a/src/lib/markdown/render.ts
+++ b/src/lib/markdown/render.ts
@@ -1,0 +1,113 @@
+import { RESUME_DATA } from '@/data/resume-data'
+import { socialBarData } from '@/data/social-bar'
+
+const SITE_URL = RESUME_DATA.personalWebsiteUrl
+
+const escapeMd = (s: string): string => s.replace(/([\\`*_[\]<>])/g, '\\$1')
+
+const link = (label: string, href: string): string => `[${escapeMd(label)}](${href})`
+
+export const renderHome = (): string => {
+  const lines: string[] = []
+  lines.push(`# ${RESUME_DATA.name}`)
+  lines.push('')
+  lines.push(RESUME_DATA.about)
+  lines.push('')
+  lines.push('## Pages')
+  lines.push('')
+  lines.push(`- ${link('About', `${SITE_URL}/about`)}`)
+  lines.push(`- ${link('Experience', `${SITE_URL}/cv`)}`)
+  lines.push('')
+  lines.push('## Elsewhere')
+  lines.push('')
+  for (const { name, link: href } of socialBarData) {
+    lines.push(`- ${link(name, href)}`)
+  }
+  lines.push('')
+  return lines.join('\n')
+}
+
+export const renderAbout = (): string => {
+  const lines: string[] = []
+  lines.push(`# About — ${RESUME_DATA.name}`)
+  lines.push('')
+  lines.push(RESUME_DATA.about)
+  lines.push('')
+  lines.push(RESUME_DATA.summary)
+  lines.push('')
+  lines.push(`Location: ${link(RESUME_DATA.location, RESUME_DATA.locationLink)}`)
+  lines.push('')
+  return lines.join('\n')
+}
+
+export const renderCv = (): string => {
+  const lines: string[] = []
+  lines.push(`# ${RESUME_DATA.name} — Experience`)
+  lines.push('')
+  lines.push(RESUME_DATA.summary)
+  lines.push('')
+
+  lines.push('## Work')
+  lines.push('')
+  for (const w of RESUME_DATA.work) {
+    const badges = w.badges.length ? ` _(${w.badges.join(', ')})_` : ''
+    lines.push(`### ${escapeMd(w.title)} — ${link(w.company, w.link)}${badges}`)
+    lines.push('')
+    lines.push(`${w.start} – ${w.end}`)
+    lines.push('')
+    lines.push(w.description)
+    lines.push('')
+  }
+
+  lines.push('## Education')
+  lines.push('')
+  for (const e of RESUME_DATA.education) {
+    lines.push(`### ${escapeMd(e.school)}`)
+    lines.push('')
+    lines.push(`${e.degree} (${e.start} – ${e.end})`)
+    lines.push('')
+  }
+
+  lines.push('## Skills')
+  lines.push('')
+  lines.push(RESUME_DATA.skills.map((s) => `\`${s}\``).join(', '))
+  lines.push('')
+
+  lines.push('## Projects')
+  lines.push('')
+  for (const p of RESUME_DATA.projects) {
+    lines.push(`### ${link(p.title, p.link.href)}`)
+    lines.push('')
+    lines.push(`_${p.techStack.join(' · ')}_`)
+    lines.push('')
+    lines.push(p.description)
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}
+
+export const markdownRoutes: Record<string, () => string> = {
+  '/': renderHome,
+  '/about': renderAbout,
+  '/cv': renderCv
+}
+
+export const renderLlmsTxt = (): string => {
+  const lines: string[] = []
+  lines.push(`# ${RESUME_DATA.name}`)
+  lines.push('')
+  lines.push(`> ${RESUME_DATA.about}`)
+  lines.push('')
+  lines.push('## Pages')
+  lines.push('')
+  lines.push(`- [Home](${SITE_URL}/index.md): Landing page`)
+  lines.push(`- [About](${SITE_URL}/about.md): Bio and summary`)
+  lines.push(`- [Experience](${SITE_URL}/cv.md): Work history, skills, projects`)
+  lines.push('')
+  return lines.join('\n')
+}
+
+export const renderLlmsFullTxt = (): string => {
+  return [renderHome(), renderAbout(), renderCv()].join('\n\n---\n\n')
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -120,10 +120,11 @@ export const routeTree = rootRouteImport
   ._addFileTypes<FileRouteTypes>()
 
 import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
+import type { startInstance } from './start.ts'
 declare module '@tanstack/react-start' {
   interface Register {
     ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
+    config: Awaited<ReturnType<typeof startInstance.getOptions>>
   }
 }

--- a/src/routes/_home/index.tsx
+++ b/src/routes/_home/index.tsx
@@ -1,6 +1,12 @@
 import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/_home/')({
+  // The static SPA shell at `/index.html` is served from the assets bucket and
+  // bypasses the Accept-negotiation middleware. The `<link rel="alternate">`
+  // here is the agent-discoverable hint that `/index.md` exists.
+  head: () => ({
+    links: [{ rel: 'alternate', type: 'text/markdown', href: '/index.md' }]
+  }),
   component: RouteComponent
 })
 

--- a/src/start.ts
+++ b/src/start.ts
@@ -1,0 +1,70 @@
+import {
+  type AnyRequestMiddleware,
+  type AnyStartInstance,
+  createStart
+} from '@tanstack/react-start'
+import { acceptPrefersMarkdown } from '@/lib/markdown/accept'
+import { markdownRoutes, renderLlmsFullTxt, renderLlmsTxt } from '@/lib/markdown/render'
+
+// `Accept-Encoding` is included so vite's dev-time compression middleware (which
+// rewrites `Vary` rather than appending) doesn't drop the `Accept` signal.
+const MD_HEADERS = {
+  'Content-Type': 'text/markdown; charset=utf-8',
+  Vary: 'Accept, Accept-Encoding',
+  'Cache-Control': 'public, max-age=300'
+}
+
+const TXT_HEADERS = {
+  'Content-Type': 'text/plain; charset=utf-8',
+  Vary: 'Accept-Encoding',
+  'Cache-Control': 'public, max-age=300'
+}
+
+const acceptMarkdown: AnyRequestMiddleware = createStart(() => ({}))
+  .createMiddleware()
+  .server(async ({ request, next }) => {
+    const isReadOnly = request.method === 'GET' || request.method === 'HEAD'
+    const pathname = new URL(request.url).pathname
+    const bodyForHead = (s: string) => (request.method === 'HEAD' ? null : s)
+
+    if (isReadOnly) {
+      if (pathname === '/llms.txt') {
+        throw new Response(bodyForHead(renderLlmsTxt()), { headers: TXT_HEADERS })
+      }
+      if (pathname === '/llms-full.txt') {
+        throw new Response(bodyForHead(renderLlmsFullTxt()), { headers: TXT_HEADERS })
+      }
+
+      let logicalPath = pathname
+      let forceMd = false
+      if (pathname.endsWith('.md') && pathname.length > 3) {
+        const stripped = pathname.slice(0, -3)
+        // `/index.md` is the canonical "home as markdown" form.
+        logicalPath = stripped === '/index' ? '/' : stripped
+        forceMd = true
+      }
+
+      const renderer = markdownRoutes[logicalPath]
+      if (renderer) {
+        if (forceMd || acceptPrefersMarkdown(request.headers.get('Accept'))) {
+          throw new Response(bodyForHead(renderer()), { headers: MD_HEADERS })
+        }
+      }
+    }
+
+    const result = await next()
+    if (markdownRoutes[pathname]) {
+      const mdHref = pathname === '/' ? '/index.md' : `${pathname}.md`
+      try {
+        result.response.headers.append('Vary', 'Accept')
+        result.response.headers.append('Link', `<${mdHref}>; rel="alternate"; type="text/markdown"`)
+      } catch {
+        // Some runtimes serve immutable Headers on Response — best-effort only.
+      }
+    }
+    return result
+  })
+
+export const startInstance: AnyStartInstance = createStart(() => ({
+  requestMiddleware: [acceptMarkdown]
+}))

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -53,11 +53,6 @@ export default $config({
         architecture: 'arm64',
         runtime: 'nodejs22.x'
       },
-      // Purge stale assets so files removed from the build (e.g. the
-      // prerendered /index.html shell, now disabled in vite.config.ts) are
-      // dropped from the bucket and KV. Without this, `/` keeps being served
-      // from a stale shell and bypasses the markdown content-negotiation
-      // middleware.
       assets: {
         purge: true
       },

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -53,6 +53,14 @@ export default $config({
         architecture: 'arm64',
         runtime: 'nodejs22.x'
       },
+      // Purge stale assets so files removed from the build (e.g. the
+      // prerendered /index.html shell, now disabled in vite.config.ts) are
+      // dropped from the bucket and KV. Without this, `/` keeps being served
+      // from a stale shell and bypasses the markdown content-negotiation
+      // middleware.
+      assets: {
+        purge: true
+      },
       router: {
         instance: router
       }

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -27,6 +27,23 @@ export default $config({
         name: baseDomain,
         aliases: isProduction ? [`www.${baseDomain}`] : undefined,
         dns
+      },
+      transform: {
+        // Forward `Accept` to the origin and key the cache on it so the
+        // markdown content-negotiation middleware in src/start.ts sees the
+        // header and CloudFront doesn't conflate HTML and markdown variants.
+        cachePolicy: {
+          parametersInCacheKeyAndForwardedToOrigin: {
+            cookiesConfig: { cookieBehavior: 'none' },
+            queryStringsConfig: { queryStringBehavior: 'all' },
+            enableAcceptEncodingBrotli: true,
+            enableAcceptEncodingGzip: true,
+            headersConfig: {
+              headerBehavior: 'whitelist',
+              headers: { items: ['x-open-next-cache-key', 'x-forwarded-host', 'accept'] }
+            }
+          }
+        }
       }
     })
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,12 +14,11 @@ export default defineConfig({
       awsLambda: { streaming: true }
     }),
     tanstackStart({
-      customViteReactPlugin: true,
-      prerender: {
-        enabled: true,
-        autoSubfolderIndex: true,
-        crawlLinks: true
-      }
+      customViteReactPlugin: true
+      // Prerendering is intentionally off: page routes must flow through the
+      // lambda so the Accept/Markdown middleware in src/start.ts can see the
+      // request. The site is tiny and CloudFront still edge-caches each
+      // variant.
     }),
     tailwindcss(),
     viteReact()


### PR DESCRIPTION
## Summary
- Adds content negotiation so `/`, `/about`, `/cv` return `text/markdown` when the client prefers it (and same content via `*.md` URL suffix). Closes #577.
- Markdown is generated as a pure function of the existing `src/data/resume-data.ts` — no parallel content files, no source duplication.
- Adds `/llms.txt` and `/llms-full.txt` for agent discovery, sourced from the same renderers.
- Widens the Router's CloudFront cache policy to forward `Accept` to the origin and key the cache on it, so HTML and Markdown variants don't conflate.

## How it works

`src/start.ts` registers a single `requestMiddleware` on the start instance:

- `Accept: text/markdown` (q-value-aware) on a known path → returns markdown directly.
- `*.md` URL suffix → forces markdown.
- `/llms.txt`, `/llms-full.txt` → text/plain index + concat.
- HTML responses on known paths get `Link: <X.md>; rel="alternate"; type="text/markdown"` for discovery.

The middleware throws a `Response` to short-circuit before TanStack Start's SSR rejects non-html `Accept` values.

## Test plan
- [ ] Preview env: `curl -i -H 'Accept: text/markdown' https://<preview>/cv` → 200, `text/markdown`, `Vary: Accept` preserved through CloudFront
- [ ] Preview env: `curl -i https://<preview>/cv.md` → 200, markdown body
- [ ] Preview env: `curl -i https://<preview>/llms.txt` and `/llms-full.txt` → text/plain
- [ ] Preview env: default browser request to `/cv` → HTML, `Link: </cv.md>; rel="alternate"; type="text/markdown"` present
- [ ] Preview env: q-value `Accept: text/markdown;q=0.5, text/html;q=0.9` → HTML
- [ ] Run https://acceptmarkdown.com/#readiness against the preview URL — should pass Vary, q-values, and Content-Type checks
- [ ] Verify CloudFront actually varies cache by `Accept` (hit `/cv` once with each Accept value, confirm both got cached separately and neither poisons the other)