### PR TITLE
Set sitemap.host so TanStack Start emits sitemap.xml

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,10 @@ export default defineConfig({
         autoSubfolderIndex: true,
         crawlLinks: true,
         filter: (page) => !/\.(pdf|png|jpg|jpeg|svg|ico|webp)$/i.test(page.path)
+      },
+      sitemap: {
+        enabled: true,
+        host: 'https://martinmiglio.dev'
       }
     }),
     tailwindcss(),


### PR DESCRIPTION
## Summary
- Adds `sitemap: { enabled: true, host: 'https://martinmiglio.dev' }` to the `tanstackStart` plugin options in `vite.config.ts`.
- The build now emits `.output/public/sitemap.xml` instead of warning `[sitemap] Pages found, but no sitemap host has been set.`
- Production host matches `package.json` `homepage`. Preview environments inherit the canonical host (out of scope; previews aren't indexed).

Closes #594.

## Generated sitemap

`.output/public/sitemap.xml`:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
  <!--This file was automatically generated by TanStack Start.-->
  <url>
    <loc>https://martinmiglio.dev/</loc>
    <lastmod>2026-05-19</lastmod>
  </url>
  <url>
    <loc>https://martinmiglio.dev/about</loc>
    <lastmod>2026-05-19</lastmod>
  </url>
  <url>
    <loc>https://martinmiglio.dev/cv</loc>
    <lastmod>2026-05-19</lastmod>
  </url>
  <url>
    <loc>https://martinmiglio.dev/resume.pdf</loc>
    <lastmod>2026-05-19</lastmod>
  </url>
</urlset>
```

Build log now shows:

```
[sitemap] Building Sitemap...
[sitemap] Writing sitemap XML at .../.output/public/sitemap.xml
[sitemap] Writing pages data at .../.output/public/pages.json
```

(no more "no sitemap host has been set" hint).

## Test plan
- [x] `bun run typecheck`
- [x] `bun run check`
- [x] `bun run build` emits `.output/public/sitemap.xml` with the canonical host
- [x] Sitemap lists `/`, `/about`, `/cv` (plus the prerendered `/resume.pdf`)