### PR TITLE
ci: bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-24.04-arm
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
           cache-dependency-glob: resume/uv.lock

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           bun-version: latest
 
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: resume/uv.lock

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -72,14 +72,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Find existing comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@v4
         id: find_comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: 'Preview Deployment'
 
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-id: ${{ steps.find_comment.outputs.comment-id }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -22,27 +22,27 @@ jobs:
     outputs:
       preview_url: ${{ steps.get_url.outputs.url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
           restore-keys: |
             bun-${{ runner.os }}-
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: .sst/platform
           key: sst-${{ runner.os }}-${{ hashFiles('bun.lock', 'sst.config.ts') }}
           restore-keys: |
             sst-${{ runner.os }}-
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
           cache-dependency-glob: resume/uv.lock
@@ -51,7 +51,7 @@ jobs:
         run: uv sync --project resume --frozen
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -42,7 +42,7 @@ jobs:
           restore-keys: |
             sst-${{ runner.os }}-
 
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: resume/uv.lock

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
           restore-keys: |
             sst-${{ runner.os }}-
 
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: resume/uv.lock

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,27 +16,27 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
           restore-keys: |
             bun-${{ runner.os }}-
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: .sst/platform
           key: sst-${{ runner.os }}-${{ hashFiles('bun.lock', 'sst.config.ts') }}
           restore-keys: |
             sst-${{ runner.os }}-
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
           cache-dependency-glob: resume/uv.lock
@@ -45,7 +45,7 @@ jobs:
         run: uv sync --project resume --frozen
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/destroy-preview.yml
+++ b/.github/workflows/destroy-preview.yml
@@ -15,20 +15,20 @@ jobs:
   destroy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
           restore-keys: |
             bun-${{ runner.os }}-
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: .sst/platform
           key: sst-${{ runner.os }}-${{ hashFiles('bun.lock', 'sst.config.ts') }}
@@ -36,7 +36,7 @@ jobs:
             sst-${{ runner.os }}-
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1


### PR DESCRIPTION
## Summary
- Silences the `Node.js 20 actions are deprecated` warning surfacing on every CI run (Node 24 becomes default 2026-06-02, Node 20 removed 2026-09-16).
- Bumps each flagged action to its latest major:
  - `actions/checkout` v4 → v6
  - `actions/cache` v4 → v5
  - `astral-sh/setup-uv` v4 → v8
  - `aws-actions/configure-aws-credentials` v4 → v6
- No input shapes changed across these majors for how we use them; only runtime is Node 24.

## Test plan
- [x] `Check` workflow passes on this PR
- [x] `Deploy Preview` workflow passes and deploys a preview
- [x] No new deprecation warnings in the run logs