### PR TITLE
chore(deps): switch dependabot to bun ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: 'npm'
+  - package-ecosystem: 'bun'
     directory: '/'
     schedule:
       interval: 'weekly'


### PR DESCRIPTION
## Summary
- Switch dependabot config from `npm` to the native `bun` ecosystem (added by GitHub in 2025) so it updates `bun.lock` alongside `package.json`.
- Fixes the recurring `error: lockfile had changes, but lockfile is frozen` CI failure on every dependabot PR (#587, #589, #590, #591), which has required hand-regenerating the lockfile.

## Test plan
- [ ] After merge, confirm next dependabot run produces PRs with `bun.lock` updates and a green Check job.